### PR TITLE
fix: set Gollum base_path and init git with main branch

### DIFF
--- a/src/cli/agents/gollum.test.ts
+++ b/src/cli/agents/gollum.test.ts
@@ -42,6 +42,7 @@ test("generateGollumConfig returns valid ruby config", () => {
   expect(config).toContain("Precious::App.set(:wiki_options");
   expect(config).toContain("index_page: 'README'");
   expect(config).toContain("h1_title: true");
+  expect(config).toContain("base_path: 'wiki'");
 });
 
 // --- startGollumServer ---

--- a/src/cli/agents/gollum.ts
+++ b/src/cli/agents/gollum.ts
@@ -58,6 +58,7 @@ export function generateGollumConfig(): string {
 Precious::App.set(:wiki_options, {
   index_page: 'README',
   h1_title: true,
+  base_path: 'wiki',
 })
 `;
 }

--- a/src/cli/handlers/install.ts
+++ b/src/cli/handlers/install.ts
@@ -40,7 +40,7 @@ export async function createWorkspace(prefix: string): Promise<void> {
     // Init git repo and commit all scaffold files so they're tracked.
     // This prevents "untracked working tree files would be overwritten"
     // errors when merging task branches back into main.
-    await Bun.spawn(["git", "init"], { cwd: workspacePath, stdout: "pipe", stderr: "pipe" }).exited;
+    await Bun.spawn(["git", "init", "-b", "main"], { cwd: workspacePath, stdout: "pipe", stderr: "pipe" }).exited;
     await Bun.spawn(["git", "add", "-A"], { cwd: workspacePath, stdout: "pipe", stderr: "pipe" }).exited;
     await Bun.spawn(["git", "commit", "-m", "initial"], { cwd: workspacePath, stdout: "pipe", stderr: "pipe" }).exited;
 


### PR DESCRIPTION
## Summary

- Adds `base_path: 'wiki'` to generated `gollum_config.rb` so Gollum prefixes all URLs with `/wiki` (CSS, JS, `/gollum/*` pages)
- Uses `git init -b main` instead of `git init` to ensure the workspace branch matches Gollum's `--ref main`
