### PR TITLE
Docs: fix comma spacing typo in backups warning

### DIFF
--- a/docs/administration/backups.mdx
+++ b/docs/administration/backups.mdx
@@ -28,7 +28,7 @@ Nightshift uses SQLite. The database is a single file at `/opt/nightshift/nights
     ```
 
     <Warning>
-    Do NOT `cp` the file while the server is running,SQLite may have uncommitted WAL data. Always use `sqlite3 .backup` or stop the server first.
+    Do NOT `cp` the file while the server is running, SQLite may have uncommitted WAL data. Always use `sqlite3 .backup` or stop the server first.
     </Warning>
   </Tab>
   <Tab title="Automated (cron)">


### PR DESCRIPTION
Fixes a minor typo in the backups documentation: adds missing space after comma in `running, SQLite`.