### PR TITLE
Test: configure pytest to include src/ on import path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["src/nightshift"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["src"]
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
Adds `pythonpath = ["src"]` to pytest config so tests can be run with `pytest` without requiring an editable install or manual `PYTHONPATH=src`. No runtime behavior changes.