### PR TITLE
Chore: trim trailing whitespace in docs/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 # Nightshift
 
-Nightshift runs AI agents in isolated [Firecracker](https://firecracker-microvm.github.io/) microVMs on bare-metal infrastructure. 
+Nightshift runs AI agents in isolated [Firecracker](https://firecracker-microvm.github.io/) microVMs on bare-metal infrastructure.
 Each agent gets its own microVM with a dedicated filesystem, network, and resource limits; so agents can execute code, edit files, and make network calls without affecting the host or each other.
 
 ## Installation

--- a/docs/administration/api-keys.mdx
+++ b/docs/administration/api-keys.mdx
@@ -15,7 +15,7 @@ There are two kinds of keys:
 
 ## Bootstrap key
 
-The bootstrap key is set via the `NIGHTSHIFT_API_KEY` environment variable. When the server starts, it hashes the value and stores it in the database. This is the only key that bypasses the API. 
+The bootstrap key is set via the `NIGHTSHIFT_API_KEY` environment variable. When the server starts, it hashes the value and stores it in the database. This is the only key that bypasses the API.
 
 The operator generates the key themselves:
 
@@ -90,7 +90,7 @@ Use the hash prefix from `api-key list`. Provide more characters if the prefix i
 
 ## Multi-tenant isolation
 
-Agents and runs are scoped by tenant ID. One tenant cannot see or run another's agents. 
+Agents and runs are scoped by tenant ID. One tenant cannot see or run another's agents.
 
 ```bash
 nightshift api-key generate --tenant acme-corp --label "acme production"

--- a/docs/deployment/cost-management.mdx
+++ b/docs/deployment/cost-management.mdx
@@ -25,7 +25,7 @@ bash cron.sh
     Creates `nightshift-lambda-role` with EC2 start/stop permissions scoped to instances tagged `nightshift-dev`.
   </Step>
   <Step title="Lambda functions">
-    Creates `nightshift-start` and `nightshift-stop` 
+    Creates `nightshift-start` and `nightshift-stop`
   </Step>
   <Step title="Scheduler IAM role">
     Creates `nightshift-scheduler-role` with `lambda:InvokeFunction` permission.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,13 +6,13 @@ description: "Platform for scurely running agents in isolated sandboxes."
 
 <img src="/logo/kokapo.gif" alt="Nightshift mascot" width="200" style={{ margin: "0 auto", display: "block" }} />
 
-Nightshift runs Agents in microVMs using [Firecracker](https://firecracker-microvm.github.io/) for [hardware level isolation](https://linux-kvm.org/page/Main_Page). 
+Nightshift runs Agents in microVMs using [Firecracker](https://firecracker-microvm.github.io/) for [hardware level isolation](https://linux-kvm.org/page/Main_Page).
 Each agent gets its own isolated VM with dedicated vCPUs, memory, filesystem, and network and streams results back via Server-Sent Events.
 
 ## What is Nightshift?
 
-Nightshift is an open source platform for deploying and running Agents in secure, efficient, isolated environments. 
-You write an agent as a Python async generator, deploy it with a single CLI command, and run it on demand. 
+Nightshift is an open source platform for deploying and running Agents in secure, efficient, isolated environments.
+You write an agent as a Python async generator, deploy it with a single CLI command, and run it on demand.
 Each run spins up a dedicated Firecracker microVM with its own resources and network, executes your agent, and streams events back in real time.
 
 A hosted platform is available at `api.nightshift.sh` or you can self-host on any linux machine with KVM support.

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -46,7 +46,7 @@ async def my_agent(prompt: str):
 
 - The function must be `async def` and use `yield` (async generator)
 - `prompt: str` is the only parameter it's what the user passes to your function at runtime
-- Each `yield` sends an SSE event back to the caller 
+- Each `yield` sends an SSE event back to the caller
 - Yielded values can be dicts, dataclasses, or Pydantic models; they're auto-serialized with a `type` field and `timestamp` added if missing
 - Inside the VM, the workspace is always at `/workspace`
     <Note>
@@ -58,7 +58,7 @@ async def my_agent(prompt: str):
     ```bash
     nightshift login --url https://api.nightshift.sh --api-key ns_<key>
     ```
-    Saves credentials to `~/.nightshift/config.toml`. 
+    Saves credentials to `~/.nightshift/config.toml`.
 
     <Note>
     If you're running a self-hosted platform, replace `api.nightshift.sh` with your server's hostname or `http://<IP>:3000`.
@@ -78,7 +78,7 @@ async def my_agent(prompt: str):
     ```
 
     This will show the agents you have deployed in Nightshift.
-    
+
   </Step>
   <Step title="Run an agent">
     ```bash


### PR DESCRIPTION
Removes trailing whitespace (and one whitespace-only line) in docs and README to reduce diff noise and avoid future lint/style issues. No functional or content changes intended.