### PR TITLE
Refactor runtime lifecycle behind SandboxDriver/SandboxInstance

### DIFF
--- a/src/nightshift/server.py
+++ b/src/nightshift/server.py
@@ -27,7 +27,7 @@ from nightshift.events import EventBuffer, InterruptedEvent, StartedEvent
 from nightshift.registry import AgentRecord, AgentRegistry
 from nightshift.sdk.app import RegisteredAgent
 from nightshift.sdk.config import AgentConfig
-from nightshift.vm.network import cleanup_stale_taps
+from nightshift.vm.firecracker_driver import FirecrackerDriver
 from nightshift.vm.pool import VMPool
 
 logger = logging.getLogger(__name__)
@@ -102,9 +102,15 @@ async def lifespan(app: FastAPI):
     _event_buffer = EventBuffer(persist=_registry.save_event)
     await bootstrap_api_key(_registry)
 
-    await cleanup_stale_taps()
+    driver = FirecrackerDriver(
+        kernel_path=_config.kernel_path,
+        base_rootfs_path=_config.base_rootfs_path,
+        event_port=_config.vm_event_port,
+    )
+    await driver.cleanup_stale_resources()
 
     _vm_pool = VMPool(
+        driver=driver,
         idle_timeout=_config.vm_idle_timeout_seconds,
         default_max_vms=_config.vm_max_per_agent,
     )
@@ -554,10 +560,7 @@ async def _run_agent_task(
     runtime_env: dict[str, str] | None = None,
     workspace_path: str = "",
 ) -> None:
-    """Background task that runs an agent in a Firecracker VM.
-
-    Uses the warm VM pool when available, falls back to one-shot run_task.
-    """
+    """Background task that runs an agent in a Firecracker-backed runtime."""
     logger.info("Run %s: starting background task for agent %s", run_id, agent_id)
 
     async def on_vm_acquired() -> None:
@@ -566,20 +569,21 @@ async def _run_agent_task(
         await _event_buffer.publish(run_id, StartedEvent(workspace=workspace_path))
 
     try:
-        if _vm_pool and agent_id:
-            from nightshift.task import run_task_pooled
+        if not _vm_pool:
+            raise RuntimeError("VM pool is not initialized")
 
-            await run_task_pooled(
-                prompt, run_id, agent, _event_buffer,
-                pool=_vm_pool, agent_id=agent_id,
-                runtime_env=runtime_env,
-                on_vm_acquired=on_vm_acquired,
-            )
-        else:
-            from nightshift.task import run_task
+        from nightshift.task import run_task
 
-            await on_vm_acquired()
-            await run_task(prompt, run_id, agent, _event_buffer)
+        await run_task(
+            prompt,
+            run_id,
+            agent,
+            _event_buffer,
+            pool=_vm_pool,
+            agent_id=agent_id,
+            runtime_env=runtime_env,
+            on_vm_acquired=on_vm_acquired,
+        )
         await registry.complete_run(run_id)
         logger.info("Run %s: completed successfully", run_id)
     except asyncio.CancelledError:

--- a/src/nightshift/task.py
+++ b/src/nightshift/task.py
@@ -12,125 +12,20 @@ Flow for a /prompt request:
 from __future__ import annotations
 
 import asyncio
-import os
-import shutil
-import tempfile
 
 import logging
 from typing import Awaitable, Callable
 
 from nightshift.config import NightshiftConfig
-from nightshift.events import (
-    CompletedEvent,
-    ErrorEvent,
-    EventLog,
-)
-from nightshift.protocol.packaging import cleanup_package, package_agent
+from nightshift.events import ErrorEvent, EventLog
 from nightshift.sdk.app import RegisteredAgent
-from nightshift.vm.manager import FirecrackerVM, VMConfig
 from nightshift.vm.pool import VMPool
+from nightshift.vm.runtime import SandboxInstance
 
 logger = logging.getLogger(__name__)
 
-AGENT_PKG_DIR = "/opt/nightshift/agent_pkg"
-
 
 async def run_task(
-    prompt: str,
-    run_id: str,
-    agent: RegisteredAgent,
-    log: EventLog,
-) -> None:
-    """Execute a task: package agent, boot VM, stream events, tear down.
-
-    Args:
-        prompt:  The user's prompt text.
-        run_id:  Unique identifier for this run.
-        agent:   The registered agent to execute.
-        log:     Event log for streaming events.
-    """
-    config = NightshiftConfig.from_env()
-    pkg_dir: str | None = None
-    staging_dir: str | None = None
-    vm: FirecrackerVM | None = None
-
-    # Workspace from agent config takes priority, then platform config.
-    # Empty workspace gets a minimal temp dir (cwd would be "/" under systemd).
-    workspace = agent.config.workspace or config.workspace
-    if not workspace:
-        workspace = tempfile.mkdtemp(prefix="nightshift-empty-ws-")
-
-    try:
-        # Package agent source code and manifest for VM injection
-        pkg_dir = await asyncio.to_thread(
-            package_agent,
-            module_path=agent.module_path,
-            function_name=agent.name,
-            prompt=prompt,
-        )
-
-        # Stage workspace into its own directory — only user files go here.
-        # The agent package is passed separately via VMConfig and gets
-        # copied to /opt/nightshift/agent_pkg in the overlay rootfs, keeping
-        # it out of /workspace so the agent only sees user content.
-        staging_dir = tempfile.mkdtemp(prefix="nightshift-staging-")
-        await asyncio.to_thread(
-            shutil.copytree,
-            workspace,
-            staging_dir,
-            symlinks=True,
-            ignore_dangling_symlinks=True,
-            dirs_exist_ok=True,
-        )
-
-        # Build env vars for the VM
-        env_vars: dict[str, str] = {}
-        for key in agent.config.forward_env:
-            val = os.environ.get(key)
-            if val:
-                env_vars[key] = val
-        env_vars.update(agent.config.env)
-        env_vars["NIGHTSHIFT_WORKSPACE"] = "/workspace"
-        env_vars["NIGHTSHIFT_AGENT_DIR"] = AGENT_PKG_DIR
-
-        vm_config = VMConfig(
-            kernel_path=config.kernel_path,
-            base_rootfs_path=config.base_rootfs_path,
-            workspace_path=staging_dir,
-            agent_pkg_path=pkg_dir,
-            env_vars=env_vars,
-            vcpu_count=agent.config.vcpu_count,
-            mem_size_mib=agent.config.mem_size_mib,
-            event_port=config.vm_event_port,
-            health_timeout=config.vm_health_timeout_seconds,
-        )
-
-        vm = FirecrackerVM(vm_id=run_id, config=vm_config)
-        await vm.start()
-        await vm.wait_for_completion(log, run_id)
-
-        await log.publish(run_id, CompletedEvent())
-
-    except Exception as e:
-        if vm:
-            serial = vm.get_serial_log()
-            logger.warning(
-                "Run %s failed: %s\n--- serial log ---\n%s\n--- end serial log ---",
-                run_id, e, serial or "(empty)",
-            )
-        await log.publish(run_id, ErrorEvent(error=str(e)))
-
-    finally:
-        if vm:
-            await vm.destroy()
-        if pkg_dir:
-            cleanup_package(pkg_dir)
-        if staging_dir:
-            shutil.rmtree(staging_dir, ignore_errors=True)
-        await log.cleanup(run_id)
-
-
-async def run_task_pooled(
     prompt: str,
     run_id: str,
     agent: RegisteredAgent,
@@ -158,7 +53,7 @@ async def run_task_pooled(
 
     try:
         for attempt in range(2):  # 1 retry after warm failure
-            vm = await pool.checkout(agent_id, agent, config)
+            vm: SandboxInstance = await pool.checkout(agent_id, agent, config)
             try:
                 if on_vm_acquired is not None:
                     await on_vm_acquired()
@@ -166,12 +61,20 @@ async def run_task_pooled(
 
                 await vm.submit_run(prompt, run_id, env_vars=runtime_env)
                 await vm.wait_for_completion(log, run_id)
-                logger.info("Run %s: wait_for_completion returned, checking in VM %s", run_id, vm.vm_id)
+                logger.info(
+                    "Run %s: wait_for_completion returned, checking in VM %s",
+                    run_id,
+                    vm.instance_id,
+                )
                 await pool.checkin(agent_id, vm)
                 logger.info("Run %s: checkin complete", run_id)
                 return
             except asyncio.CancelledError:
-                logger.info("Run %s: cancelled while running on VM %s", run_id, vm.vm_id)
+                logger.info(
+                    "Run %s: cancelled while running on VM %s",
+                    run_id,
+                    vm.instance_id,
+                )
                 await pool.invalidate_vm(agent_id, vm)
                 raise
             except Exception as exc:
@@ -181,7 +84,11 @@ async def run_task_pooled(
                 logger.warning(
                     "Run %s failed on VM %s (attempt %d): %s\n"
                     "--- serial log ---\n%s\n--- end serial log ---",
-                    run_id, vm.vm_id, attempt + 1, exc, serial or "(empty)",
+                    run_id,
+                    vm.instance_id,
+                    attempt + 1,
+                    exc,
+                    serial or "(empty)",
                 )
                 await pool.invalidate_vm(agent_id, vm)
                 if attempt == 0:

--- a/src/nightshift/vm/firecracker_driver.py
+++ b/src/nightshift/vm/firecracker_driver.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nightshift.vm.manager import VMConfig, FirecrackerVM
+from nightshift.vm.network import cleanup_stale_taps
+from nightshift.vm.runtime import RuntimeConfig, SandboxDriver, SandboxInstance
+
+
+@dataclass
+class FirecrackerDriver(SandboxDriver):
+    """SandboxDriver implementation for Firecracker microVMs.
+
+    This is a thin adapter that maps the generic RuntimeConfig into the existing
+    Firecracker VMConfig and returns an unstarted FirecrackerVM.
+    """
+
+    kernel_path: str
+    base_rootfs_path: str
+    event_port: int = 8080
+
+    def create_instance(
+        self,
+        instance_id: str,
+        config: RuntimeConfig,
+    ) -> SandboxInstance:
+        vm_config = VMConfig(
+            kernel_path=self.kernel_path,
+            base_rootfs_path=self.base_rootfs_path,
+            workspace_path=config.workspace_path,
+            agent_pkg_path=config.agent_pkg_path,
+            env_vars=config.env_vars,
+            vcpu_count=config.vcpu_count,
+            mem_size_mib=config.mem_size_mib,
+            event_port=self.event_port,
+            health_timeout=config.health_timeout,
+        )
+        return FirecrackerVM(vm_id=instance_id, config=vm_config)
+
+    async def cleanup_stale_resources(self) -> None:
+        """Remove leftover TAP devices and related resources from prior runs."""
+        await cleanup_stale_taps()
+

--- a/src/nightshift/vm/manager.py
+++ b/src/nightshift/vm/manager.py
@@ -123,6 +123,11 @@ class FirecrackerVM:
         self._serial_task: asyncio.Task | None = None
 
     @property
+    def instance_id(self) -> str:
+        """Identifier used by the runtime pool and driver layer."""
+        return self.vm_id
+
+    @property
     def guest_url(self) -> str:
         """Base URL to reach the guest agent's HTTP server over the TAP network.
 
@@ -523,5 +528,12 @@ class FirecrackerVM:
         # Set locally administered bit (0x02), clear multicast bit (0xFE)
         octets[0] = (octets[0] | 0x02) & 0xFE
         return ":".join(f"{o:02x}" for o in octets)
+
+    async def __aenter__(self) -> "FirecrackerVM":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.destroy()
 
 

--- a/src/nightshift/vm/pool.py
+++ b/src/nightshift/vm/pool.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from nightshift.config import NightshiftConfig
 from nightshift.protocol.packaging import cleanup_package, package_agent
 from nightshift.sdk.app import RegisteredAgent
-from nightshift.vm.manager import FirecrackerVM, VMConfig
+from nightshift.vm.runtime import SandboxDriver, SandboxInstance, RuntimeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ AGENT_PKG_DIR = "/opt/nightshift/agent_pkg"
 class _PoolEntry:
     """Tracks a single VM in the pool."""
 
-    vm: FirecrackerVM | None
+    vm: SandboxInstance | None
     agent_id: str
     pkg_dir: str
     staging_dir: str
@@ -43,7 +43,8 @@ class _PoolEntry:
 class VMPool:
     """Multi-VM pool with checkout/checkin, idle timeout, and scaling."""
 
-    def __init__(self, idle_timeout: int, default_max_vms: int) -> None:
+    def __init__(self, driver: SandboxDriver, idle_timeout: int, default_max_vms: int) -> None:
+        self._driver = driver
         self._agents: dict[str, list[_PoolEntry]] = {}
         self._idle_timeout = idle_timeout
         self._default_max_vms = default_max_vms
@@ -54,7 +55,7 @@ class VMPool:
         agent_id: str,
         agent: RegisteredAgent,
         config: NightshiftConfig,
-    ) -> FirecrackerVM:
+    ) -> SandboxInstance:
         """Get a warm VM or cold-start a new one.
 
         Blocks if all VMs are busy and at the concurrency limit.
@@ -116,7 +117,7 @@ class VMPool:
             assert entry.vm is not None
             healthy = await entry.vm.is_healthy_async()
             if not healthy:
-                logger.warning("Warm VM %s unhealthy, removing", entry.vm.vm_id)
+                logger.warning("Warm VM %s unhealthy, removing", entry.vm.instance_id)
                 await self._remove_entry(agent_id, entry)
                 raise RuntimeError(
                     f"Warm VM unhealthy for agent {agent_id}"
@@ -139,9 +140,9 @@ class VMPool:
                 self._cond.notify_all()
             raise
 
-    async def checkin(self, agent_id: str, vm: FirecrackerVM) -> None:
+    async def checkin(self, agent_id: str, vm: SandboxInstance) -> None:
         """Return a VM to the pool after a successful run."""
-        logger.info("Checkin VM %s for agent %s", vm.vm_id, agent_id)
+        logger.info("Checkin VM %s for agent %s", vm.instance_id, agent_id)
         async with self._cond:
             entries = self._agents.get(agent_id, [])
             for e in entries:
@@ -152,14 +153,19 @@ class VMPool:
                     )
                     logger.info(
                         "VM %s checked in, idle timer started (%ds)",
-                        vm.vm_id, self._idle_timeout,
+                        vm.instance_id,
+                        self._idle_timeout,
                     )
                     break
             else:
-                logger.warning("Checkin: VM %s not found in pool for agent %s", vm.vm_id, agent_id)
+                logger.warning(
+                    "Checkin: VM %s not found in pool for agent %s",
+                    vm.instance_id,
+                    agent_id,
+                )
             self._cond.notify_all()
 
-    async def invalidate_vm(self, agent_id: str, vm: FirecrackerVM) -> None:
+    async def invalidate_vm(self, agent_id: str, vm: SandboxInstance) -> None:
         """Destroy one specific VM (e.g. on error during a run)."""
         async with self._cond:
             entries = self._agents.get(agent_id, [])
@@ -202,8 +208,8 @@ class VMPool:
         entry: _PoolEntry,
         agent: RegisteredAgent,
         config: NightshiftConfig,
-    ) -> FirecrackerVM:
-        """Provision a new VM from scratch."""
+    ) -> SandboxInstance:
+        """Provision a new sandbox instance from scratch."""
         workspace = entry.workspace_dest
 
         # Package agent in a thread (synchronous file I/O)
@@ -230,24 +236,21 @@ class VMPool:
         # Build static env vars (forward_env + agent.config.env + NIGHTSHIFT_*)
         env_vars = _build_static_env_vars(agent, config)
 
-        vm_config = VMConfig(
-            kernel_path=config.kernel_path,
-            base_rootfs_path=config.base_rootfs_path,
+        runtime_config = RuntimeConfig(
             workspace_path=staging_dir,
             agent_pkg_path=pkg_dir,
             env_vars=env_vars,
             vcpu_count=agent.config.vcpu_count,
             mem_size_mib=agent.config.mem_size_mib,
-            event_port=config.vm_event_port,
             health_timeout=config.vm_health_timeout_seconds,
         )
 
-        vm_id = str(uuid.uuid4())
-        vm = FirecrackerVM(vm_id=vm_id, config=vm_config)
-        await vm.start()
+        instance_id = str(uuid.uuid4())
+        instance = self._driver.create_instance(instance_id, runtime_config)
+        await instance.start()
 
-        logger.info("Cold-started VM %s for agent %s", vm_id, entry.agent_id)
-        return vm
+        logger.info("Cold-started instance %s for agent %s", instance_id, entry.agent_id)
+        return instance
 
     async def _idle_expire(self, agent_id: str, entry: _PoolEntry) -> None:
         """Idle timer: destroy the VM after timeout if still idle."""
@@ -266,7 +269,7 @@ class VMPool:
 
         logger.info(
             "Idle timeout: destroying VM %s for agent %s",
-            entry.vm.vm_id if entry.vm else "?",
+            entry.vm.instance_id if entry.vm else "?",
             agent_id,
         )
         await self._destroy_entry(entry)
@@ -289,19 +292,24 @@ class VMPool:
         if entry.vm:
             try:
                 if entry.stateful:
-                    logger.info("Extracting workspace for stateful VM %s → %s", entry.vm.vm_id, entry.workspace_dest)
+                    logger.info(
+                        "Extracting workspace for stateful VM %s → %s",
+                        entry.vm.instance_id,
+                        entry.workspace_dest,
+                    )
                     await entry.vm.copy_workspace_out(entry.workspace_dest)
-                    logger.info("Workspace extracted for VM %s", entry.vm.vm_id)
+                    logger.info("Workspace extracted for VM %s", entry.vm.instance_id)
             except Exception:
                 logger.exception(
-                    "Failed to extract workspace for VM %s", entry.vm.vm_id
+                    "Failed to extract workspace for VM %s",
+                    entry.vm.instance_id,
                 )
             try:
-                logger.info("Destroying VM %s", entry.vm.vm_id)
+                logger.info("Destroying VM %s", entry.vm.instance_id)
                 await entry.vm.destroy()
-                logger.info("VM %s destroyed", entry.vm.vm_id)
+                logger.info("VM %s destroyed", entry.vm.instance_id)
             except Exception:
-                logger.exception("Failed to destroy VM %s", entry.vm.vm_id)
+                logger.exception("Failed to destroy VM %s", entry.vm.instance_id)
 
         if entry.pkg_dir:
             cleanup_package(entry.pkg_dir)

--- a/src/nightshift/vm/runtime.py
+++ b/src/nightshift/vm/runtime.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable, Dict, Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nightshift.events import EventLog
+
+
+@dataclass
+class RuntimeConfig:
+    """Backend-agnostic configuration for a single runtime instance."""
+
+    # Host directory to mount or inject as the instance's /workspace.
+    workspace_path: str
+
+    # Host directory containing the packaged agent code.
+    agent_pkg_path: str = ""
+
+    # Environment variables to inject into the instance.
+    env_vars: Dict[str, str] = field(default_factory=dict)
+
+    # Resource limits. Drivers may ignore these if the backend does not
+    # support fine-grained resource control.
+    vcpu_count: int = 2
+    mem_size_mib: int = 2048
+
+    # Maximum seconds to wait for the instance to become healthy.
+    health_timeout: int = 60
+
+
+@runtime_checkable
+class SandboxInstance(Protocol):
+    """Handle to a single running sandbox (VM, container, process, and so on)."""
+
+    @property
+    def instance_id(self) -> str:
+        """Unique identifier for this instance."""
+        ...
+
+    async def start(self) -> None:
+        """Provision resources and boot the instance."""
+        ...
+
+    async def wait_for_completion(self, log: "EventLog", run_id: str) -> None:
+        """Stream events from the instance until a terminal event."""
+        ...
+
+    async def submit_run(
+        self,
+        prompt: str,
+        run_id: str,
+        env_vars: Optional[Dict[str, str]] = None,
+    ) -> None:
+        ...
+
+    async def copy_workspace_out(self, dest_path: str) -> None:
+        """Extract the modified workspace from the instance to dest_path."""
+        ...
+
+    async def destroy(self) -> None:
+        """Tear down all resources associated with this instance."""
+        ...
+
+    def is_healthy(self) -> bool:
+        """Quick synchronous liveness check."""
+        ...
+
+    async def is_healthy_async(self) -> bool:
+        """Full async health check."""
+        ...
+
+    def get_serial_log(self) -> Optional[str]:
+        """Return debug output captured from the instance, if any."""
+        ...
+
+    async def __aenter__(self) -> "SandboxInstance":
+        ...
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        ...
+
+
+@runtime_checkable
+class SandboxDriver(Protocol):
+    """Factory that creates SandboxInstance objects and cleans up stale resources."""
+
+    def create_instance(
+        self,
+        instance_id: str,
+        config: RuntimeConfig,
+    ) -> SandboxInstance:
+        """Create a new sandbox instance (not yet started)."""
+        ...
+
+    async def cleanup_stale_resources(self) -> None:
+        """Clean up orphaned resources from a previous server process."""
+        ...
+

--- a/tests/test_vm_runtime_pool.py
+++ b/tests/test_vm_runtime_pool.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any
+
+import pytest
+
+from nightshift.config import NightshiftConfig
+from nightshift.events import EventLog
+from nightshift.sdk.app import RegisteredAgent
+from nightshift.sdk.config import AgentConfig
+from nightshift.vm.pool import VMPool
+from nightshift.vm.runtime import SandboxDriver, SandboxInstance, RuntimeConfig
+import nightshift.task as task_module
+
+
+@dataclass
+class FakeInstance(SandboxInstance):
+    _instance_id: str
+    started: bool = False
+    destroyed: bool = False
+    submit_calls: int = 0
+    healthy: bool = True
+    fail_first_submit: bool = False
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def wait_for_completion(self, log: EventLog, run_id: str) -> None:
+        # No-op for tests; real implementation streams events.
+        return None
+
+    async def submit_run(
+        self,
+        prompt: str,
+        run_id: str,
+        env_vars: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.submit_calls += 1
+        if self.fail_first_submit and self.submit_calls == 1:
+            raise RuntimeError("synthetic failure on first submit_run")
+
+    async def copy_workspace_out(self, dest_path: str) -> None:
+        return None
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+    def is_healthy(self) -> bool:
+        return self.healthy
+
+    async def is_healthy_async(self) -> bool:
+        return self.healthy
+
+    def get_serial_log(self) -> Optional[str]:
+        return ""
+
+    async def __aenter__(self) -> "FakeInstance":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.destroy()
+
+
+@dataclass
+class FakeDriver(SandboxDriver):
+    created: list[tuple[str, RuntimeConfig]] = field(default_factory=list)
+    instances: list[FakeInstance] = field(default_factory=list)
+    fail_first_submit: bool = False
+
+    def create_instance(
+        self,
+        instance_id: str,
+        config: RuntimeConfig,
+    ) -> SandboxInstance:
+        self.created.append((instance_id, config))
+        inst = FakeInstance(
+            _instance_id=instance_id,
+            fail_first_submit=self.fail_first_submit,
+        )
+        self.instances.append(inst)
+        return inst
+
+    async def cleanup_stale_resources(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_vm_pool_uses_driver_create_and_start(tmp_path) -> None:
+    """VMPool delegates instance creation and start to the injected driver."""
+    driver = FakeDriver()
+    pool = VMPool(driver=driver, idle_timeout=60, default_max_vms=1)
+
+    agent_file = tmp_path / "agent.py"
+    agent_file.write_text(
+        "async def test_agent(prompt: str):\n    yield {'type': 'message', 'text': 'ok'}\n",
+        encoding="utf-8",
+    )
+
+    cfg = NightshiftConfig(workspace=str(tmp_path))
+    agent_cfg = AgentConfig(workspace=str(tmp_path))
+    agent = RegisteredAgent(
+        name="test_agent",
+        fn=lambda prompt: None,
+        config=agent_cfg,
+        module_path=str(agent_file),
+    )
+
+    instance = await pool.checkout("agent-1", agent, cfg)
+
+    assert isinstance(instance, FakeInstance)
+    assert driver.created, "driver.create_instance should be called"
+    assert instance.started is True
+
+    await pool.shutdown()
+    assert instance.destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_run_task_retries_on_warm_failure(monkeypatch, tmp_path) -> None:
+    """run_task retries once when a warm instance fails and uses the pool."""
+    driver = FakeDriver(fail_first_submit=True)
+    pool = VMPool(driver=driver, idle_timeout=60, default_max_vms=2)
+
+    agent_file = tmp_path / "agent.py"
+    agent_file.write_text(
+        "async def test_agent(prompt: str):\n    yield {'type': 'message', 'text': 'ok'}\n",
+        encoding="utf-8",
+    )
+
+    cfg = NightshiftConfig(workspace=str(tmp_path))
+    monkeypatch.setattr(
+        task_module.NightshiftConfig,
+        "from_env",
+        staticmethod(lambda: cfg),
+    )
+
+    agent_cfg = AgentConfig(workspace=str(tmp_path))
+    agent = RegisteredAgent(
+        name="test_agent",
+        fn=lambda prompt: None,
+        config=agent_cfg,
+        module_path=str(agent_file),
+    )
+
+    log = EventLog()
+
+    await task_module.run_task(
+        prompt="hello",
+        run_id="run-1",
+        agent=agent,
+        log=log,
+        pool=pool,
+        agent_id="agent-1",
+        runtime_env=None,
+        on_vm_acquired=None,
+    )
+
+    assert len(driver.instances) == 2
+    assert driver.instances[0].submit_calls == 1
+    assert driver.instances[1].submit_calls == 1
+
+    await pool.shutdown()
+


### PR DESCRIPTION
Implemented ✅ **#111 (Runtime Driver interface and lifecycle manager)** in branch `feat/runtime-driver-v2`.

### What’s done
- Introduced runtime abstraction boundary with:
  - `SandboxDriver`
  - `SandboxInstance`
  - `RuntimeConfig` (unchanged name)
- Refactored Firecracker behind adapter layer (`FirecrackerDriver`).
- Updated pool/task/server orchestration to depend on sandbox interfaces instead of direct Firecracker VM types.
- Unified execution flow through pooled runtime path.
- Added/updated tests for pool-driver contract and retry behavior.

### Validation
```bash
py -3.12 -m pytest -q tests/test_vm_runtime_pool.py tests/test_events.py tests/test_registry.py tests/test_protocol.py tests/test_sdk.py